### PR TITLE
Add on_idle callback helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,35 @@ client.on_callback do |event, value|
 end
 ```
 
+### Idle callbacks
+
+MPD also supports the `idle` command for subsystem-level notifications such as
+`player`, `playlist`, `stored_playlist`, `database`, and `mixer`.
+
+`#on_idle` starts a background fiber that repeatedly waits for idle events and
+passes the changed subsystem names to your callback.
+
+```crystal
+idle_client = MPD::Client.new
+
+idle_client.on_idle(["player", "playlist", "stored_playlist"]) do |events|
+  if events.includes?("stored_playlist")
+    puts "Stored playlists changed"
+  end
+
+  if events.includes?("player")
+    puts "Playback state changed"
+  end
+end
+
+# Keep the program running
+loop { sleep 1.second }
+```
+
+The MPD `idle` command blocks the connection while it waits for changes. For GUI
+apps and other programs that need to send commands while listening, create a
+dedicated `MPD::Client` for `#on_idle`.
+
 ### Binary responses
 
 Some commands can return binary data.

--- a/src/crystal_mpd/client.cr
+++ b/src/crystal_mpd/client.cr
@@ -131,6 +131,33 @@ module MPD
       @on_any_callbacks << block
     end
 
+    # Register a callback for MPD idle subsystem changes.
+    #
+    # This starts a background fiber that repeatedly calls `#idle` and yields
+    # the changed subsystem names to the block.
+    #
+    # MPD's `idle` command blocks the connection while it waits for changes, so
+    # use a dedicated client for idle listeners when the application also needs
+    # to send regular commands.
+    #
+    # ```
+    # listener = MPD::Client.new
+    #
+    # listener.on_idle(["player", "playlist"]) do |events|
+    #   puts events
+    # end
+    # ```
+    def on_idle(subsystems : Array(String)? = nil, &block : Array(String) -> _) : Fiber
+      fiber = spawn do
+        loop do
+          block.call(idle(subsystems) || [] of String)
+        end
+      end
+
+      Fiber.yield
+      fiber
+    end
+
     # Emit event: calls both per-event and global callbacks
     private def emit(event : Event, arg : String)
       # Call specific event listeners


### PR DESCRIPTION
## Motivation

MPD's `idle` command is useful for reacting to subsystem-level changes such as `player`, `playlist`, `stored_playlist`, `database`, and `mixer`.

Before this change, users could call `client.idle` manually in their own loop. That works, but every application has to repeat the same background listener pattern.

## Changes

- Add `MPD::Client#on_idle`
- Start a background fiber that repeatedly waits for `idle` events
- Yield changed subsystem names to the provided callback
- Return the listener fiber to the caller

## Example

```crystal
idle_client = MPD::Client.new

idle_client.on_idle(["player", "playlist", "stored_playlist"]) do |events|
  if events.includes?("stored_playlist")
    puts "Stored playlists changed"
  end
end